### PR TITLE
Added validator for site infrastructure

### DIFF
--- a/config_validation_engine/validators/schema/site_infrastructure_schema.yaml
+++ b/config_validation_engine/validators/schema/site_infrastructure_schema.yaml
@@ -1,0 +1,5 @@
+site_infrastructure: list(include('domain_ip_record'))
+
+domain_ip_record:
+  fqdn: domain()
+  ip_address: ip(version=4)

--- a/config_validation_engine/validators/tests/site_infrastructure.yaml
+++ b/config_validation_engine/validators/tests/site_infrastructure.yaml
@@ -1,0 +1,5 @@
+site_infrastructure:
+- fqdn: lightweight_component01.cern.ch
+  ip_address: 192.168.0.4
+- fqdn: lightweight_component02.cern.ch
+  ip_address: 192.168.0.5

--- a/config_validation_engine/validators/validators.py
+++ b/config_validation_engine/validators/validators.py
@@ -4,7 +4,7 @@ from .constraints import EmailDomain
 from validate_email import validate_email
 from urlparse import urlparse
 from math import ceil, floor
-
+from fqdn import FQDN
 
 class Email(Validator):
     """Email Validator"""
@@ -59,6 +59,21 @@ class URL(Validator):
             return True
         return False
 
+class Domain(Validator):
+    """Domain Validator"""
+    tag = 'domain'
+
+    def _is_valid(self, value):
+        fqdn = FQDN(value)
+
+        return fqdn.is_valid
+
+    def fail(self, value):
+        return "{value} is not a valid {tag} value. An acceptable example is {example}".format(
+            value = value,
+            tag = self.tag,
+            example = "lightweight_component01.cern.ch"
+            )
 
 def all_config_validators():
     validators = DefaultValidators.copy()
@@ -66,4 +81,6 @@ def all_config_validators():
     validators[Longitude.tag] = Longitude
     validators[Latitude.tag] = Latitude
     validators[URL.tag] = URL
+    validators[Domain.tag] = Domain
+
     return validators

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,11 @@
 astroid==1.6.1
 attrs==17.4.0
 Babel==2.6.0
+fqdn==1.1.0
 isort==4.2.15
 lazy-object-proxy==1.3.1
 mccabe==0.6.1
-mysql-connector==2.1.6
+mysql-connector>=2.1.6
 pbr==4.3.0
 pluggy==0.6.0
 ply==3.11


### PR DESCRIPTION
Hi,

I've added validator for site infrastructure, fixing #4.

We had to validate two fields - fqdn and ipv4 address - for the schema. 

For fqdn, instead of going with a custom regex, I've used `fqdn` module from pypi as it implements fqdn validation fully compliant with RFC-1035 making it more robust. 

For ip4 address, I've used `yamale`'s built-in `ip` validator. 

Looking forward to reviews on the PR. 